### PR TITLE
Fix crash when handling offline players and user input

### DIFF
--- a/src/IvanCraft623/RankSystem/form/UserManageForm.php
+++ b/src/IvanCraft623/RankSystem/form/UserManageForm.php
@@ -45,7 +45,8 @@ final class UserManageForm {
 						$player, $this->translator->translate($player, "form.user_manage.title"), $this->translator->translate($player, "form.user_manage.insert_user"), $this->translator->translate($player, "text.user") . ":"
 					)->onCompletion(
 						function (string $user) use ($player) {
-							FormManager::getInstance()->sendUserInfo($player, SessionManager::getInstance()->get($user), true);
+							$sanitizedUser = trim($user);
+							FormManager::getInstance()->sendUserInfo($player, SessionManager::getInstance()->get($sanitizedUser), true);
 						}, function () {} // No response
 					);
 					break;

--- a/src/IvanCraft623/RankSystem/session/SessionManager.php
+++ b/src/IvanCraft623/RankSystem/session/SessionManager.php
@@ -26,12 +26,23 @@ final class SessionManager {
 	private array $sessions = [];
 
 	public function get(Player|string $player) : Session {
-		$player = ($player instanceof Player) ? $player->getName() : $player;
-		if (isset($this->sessions[$player])) {
-			return $this->sessions[$player];
+		$playerName = ($player instanceof Player) ? $player->getName() : $player;
+
+		// First, try a direct match (most common case)
+		if (isset($this->sessions[$playerName])) {
+			return $this->sessions[$playerName];
 		}
-		$session = new Session($player);
-		$this->sessions[$player] = $session;
+
+		// If not found, try a case-insensitive search
+		foreach ($this->sessions as $name => $session) {
+			if (strcasecmp($name, $playerName) === 0) {
+				return $session; // Found! Returning existing session.
+			}
+		}
+
+		// If still not found, create a new one
+		$session = new Session($playerName);
+		$this->sessions[$playerName] = $session;
 		return $session;
 	}
 

--- a/src/IvanCraft623/RankSystem/tag/TagManager.php
+++ b/src/IvanCraft623/RankSystem/tag/TagManager.php
@@ -48,7 +48,8 @@ final class TagManager {
 			return $user->getName();
 		}));
 		$this->registerTag(new Tag("display_name", static function (Session $user): string {
-			return $user->getPlayer()->getDisplayName();
+			$player = $user->getPlayer();
+			return $player !== null ? $player->getDisplayName() : $user->getName();
 		}));
 		$this->registerTag(new Tag("nametag_ranks_prefix", static function(Session $user) : string {
 			return implode("", array_map(fn(Rank $rank) => $rank->getNameTagFormat()["prefix"], $user->getRanks()));


### PR DESCRIPTION
This pull request fixes a critical crash that occurs when trying to view information about an offline player or a player whose session is not properly loaded. It also fixes the root cause of incorrect session creation from user input in forms.

### The Problem

1. **Crash on Offline Player:** The code would crash with a "Call to a member function getDisplayName() on null" error when trying to generate a nametag for an offline player, as the player object was null.
2. **Incorrect Session Creation:** When entering a player's name in the user management form, a new, empty session was being created if the input string had trailing spaces or different capitalization. This also led to the same crash, even for online players.

### The Solution

This PR introduces a multi-level fix:

- **`TagManager.php`:** A safety check has been added to the `display_name` tag. It now verifies if the player object is null and falls back to the user's name, preventing any crashes.
- **`UserManageForm.php`:** The user input for the nickname is now sanitized with `trim()` to remove any leading or trailing whitespace.
- **`SessionManager.php`:** The session lookup logic has been improved to be case-insensitive. If an exact match for a session is not found, it performs a case-insensitive search before creating a new session.

These changes together make the player information forms more robust, prevent crashes, and ensure that the correct user session is always found.